### PR TITLE
chore(githubrelease): deprecate key hash/name for taghash/tagname

### DIFF
--- a/pkg/plugins/resources/githubrelease/condition.go
+++ b/pkg/plugins/resources/githubrelease/condition.go
@@ -20,7 +20,7 @@ func (gr GitHubRelease) Condition(source string, scm scm.ScmHandler) (pass bool,
 	}
 
 	var versions []string
-	if gr.spec.Key == KeyHash {
+	if gr.spec.Key == KeyTagHash {
 		versions, err = gr.ghHandler.SearchReleasesByTagHash(gr.typeFilter)
 	} else if gr.spec.Key == KeyTitle {
 		versions, err = gr.ghHandler.SearchReleasesByTitle(gr.typeFilter)

--- a/pkg/plugins/resources/githubrelease/source.go
+++ b/pkg/plugins/resources/githubrelease/source.go
@@ -43,7 +43,7 @@ func (gr *GitHubRelease) Source(workingDir string, resultSource *result.Source) 
 
 	value := gr.foundVersion.GetVersion()
 
-	if gr.spec.Key == KeyHash {
+	if gr.spec.Key == KeyTagHash {
 		for _, release := range releaseRefs {
 			if release.TagName == value {
 				value = release.TagCommit.Oid


### PR DESCRIPTION
Deprecate key hash/name in favor of taghash/tagname
While here, I also rewrite comment used to generate documentation on updatecli.io and in IDE 